### PR TITLE
remove typo from portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -168,7 +168,7 @@ msgstr "O número máximo de dias mostrados na lista"
 
 #: src/gtk/preferences_window.ui:96
 msgid "_Delete confirmation"
-msgstr "_Confirmar.deleção"
+msgstr "_Confirmar antes de deletar"
 
 #: src/gtk/preferences_window.ui:108
 msgid "_Show seconds"


### PR DESCRIPTION
Fixed a typo (using "." instead of " ", oopsie) and improved clarity a bit. 