### PR TITLE
fix: CSV export options translatable

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -83,7 +83,7 @@ impl SortOrder {
     num_derive::FromPrimitive,
 )]
 pub enum TaskSort {
-    StartTime,
+    StartTime = 0,
     StopTime,
     TaskName,
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -16,7 +16,6 @@
 
 use chrono::{DateTime, Local};
 use directories::ProjectDirs;
-use gtk::glib;
 use rusqlite::{Connection, Result};
 use std::convert::TryFrom;
 use std::fs::create_dir_all;
@@ -41,13 +40,9 @@ pub struct Task {
     Ord,
     num_derive::FromPrimitive,
     num_derive::ToPrimitive,
-    glib::Enum,
 )]
-#[enum_type(name = "SortOrder")]
 pub enum SortOrder {
-    #[enum_value(name = "Ascending", nick = "Ascending")]
     Ascending = 0,
-    #[enum_value(name = "Descending", nick = "Descending")]
     Descending,
 }
 
@@ -86,15 +81,10 @@ impl SortOrder {
     Ord,
     num_derive::ToPrimitive,
     num_derive::FromPrimitive,
-    glib::Enum,
 )]
-#[enum_type(name = "TaskSort")]
 pub enum TaskSort {
-    #[enum_value(name = "StartTime", nick = "Start time")]
     StartTime,
-    #[enum_value(name = "StopTime", nick = "Stop time")]
     StopTime,
-    #[enum_value(name = "TaskName", nick = "Task name")]
     TaskName,
 }
 

--- a/src/gtk/dialogs.ui
+++ b/src/gtk/dialogs.ui
@@ -68,12 +68,13 @@
                   <object class="AdwComboRow" id="csv_export_tasksort_row">
                     <property name="title" translatable="yes">Sort by</property>
                     <property name="model">
-                      <object class="AdwEnumListModel">
-                        <property name="enum-type">TaskSort</property>
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Start time</item>
+                          <item translatable="yes">Stop time</item>
+                          <item translatable="yes">Task name</item>
+                        </items>
                       </object>
-                    </property>
-                    <property name="expression">
-                      <lookup type="AdwEnumListItem" name="nick" />
                     </property>
                   </object>
                 </child>
@@ -81,12 +82,12 @@
                   <object class="AdwComboRow" id="csv_export_sortorder_row">
                     <property name="title" translatable="yes">Sort order</property>
                     <property name="model">
-                      <object class="AdwEnumListModel">
-                        <property name="enum-type">SortOrder</property>
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Ascending</item>
+                          <item translatable="yes">Descending</item>
+                        </items>
                       </object>
-                    </property>
-                    <property name="expression">
-                      <lookup type="AdwEnumListItem" name="nick" />
                     </property>
                   </object>
                 </child>

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -40,8 +40,6 @@ use crate::ui::FurHistoryBox;
 use crate::FurtheranceApplication;
 
 mod imp {
-    use crate::database::{SortOrder, TaskSort};
-
     use super::*;
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -87,8 +85,6 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             FurHistoryBox::static_type();
-            TaskSort::static_type();
-            SortOrder::static_type();
             Self::bind_template(klass);
         }
 
@@ -916,7 +912,6 @@ impl FurtheranceWindow {
         let imp = imp::FurtheranceWindow::from_instance(self);
         imp.win_box.set_valign(align);
     }
-
 }
 
 impl Default for FurtheranceWindow {


### PR DESCRIPTION
This makes the task sort and sort order export options translatable by switching from a enum list model to a string list model.
It is a little less elegant, because we now manually need to make sure the item order of the string list matches the enum order

fixes  #68 when merged