### PR TITLE
Remove cargo.lock from meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,6 @@ i18n = import('i18n')
 
 cargo_sources = files(
   'Cargo.toml',
-  'Cargo.lock',
 )
 
 subdir('data')


### PR DESCRIPTION
Having cargo.lock in meson.build causes an error if building with the AUR script (possibly also in a normal build).