### PR TITLE
Implement task name autocompletion

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -349,7 +349,7 @@ pub fn get_list_by_id(id_list: Vec<i32>) -> Result<Vec<Task>, rusqlite::Error> {
     Ok(tasks_vec)
 }
 
-pub fn get_list_by_name_or_tag(task_name: String) -> Result<Vec<Task>, rusqlite::Error> {
+pub fn get_list_by_name(task_name: String) -> Result<Vec<Task>, rusqlite::Error> {
     let conn = Connection::open(get_directory())?;
     let mut tasks_vec: Vec<Task> = Vec::new();
     let name_param = format!("%{}%", task_name);

--- a/src/database.rs
+++ b/src/database.rs
@@ -38,6 +38,12 @@ pub struct Task {
     pub tags: String,
 }
 
+impl ToString for Task {
+    fn to_string(&self) -> String {
+        format!("{} #{}", self.task_name, self.tags)
+    }
+}
+
 #[derive(
     Debug,
     Clone,

--- a/src/database.rs
+++ b/src/database.rs
@@ -343,6 +343,29 @@ pub fn get_list_by_id(id_list: Vec<i32>) -> Result<Vec<Task>, rusqlite::Error> {
     Ok(tasks_vec)
 }
 
+pub fn get_list_by_name_or_tag(task_name: String) -> Result<Vec<Task>, rusqlite::Error> {
+    let conn = Connection::open(get_directory())?;
+    let mut tasks_vec: Vec<Task> = Vec::new();
+    let name_param = format!("%{}%", task_name);
+
+    let mut query = conn.prepare("SELECT * FROM tasks WHERE lower(task_name) LIKE lower(:task_name)")?;
+    let task_iter = query.query_map(&[(":task_name", &name_param)], |row| {
+        Ok(Task {
+            id: row.get(0)?,
+            task_name: row.get(1)?,
+            start_time: row.get(2)?,
+            stop_time: row.get(3)?,
+            tags: row.get(4)?,
+        })
+    })?;
+
+    for task_item in task_iter {
+        tasks_vec.push(task_item.unwrap());
+    }
+
+    Ok(tasks_vec)
+}
+
 pub fn check_for_tasks() -> Result<String> {
     let conn = Connection::open(get_directory())?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -354,7 +354,7 @@ pub fn get_list_by_name(task_name: String) -> Result<Vec<Task>, rusqlite::Error>
     let mut tasks_vec: Vec<Task> = Vec::new();
     let name_param = format!("%{}%", task_name);
 
-    let mut query = conn.prepare("SELECT * FROM tasks WHERE lower(task_name) LIKE lower(:task_name)")?;
+    let mut query = conn.prepare("SELECT * FROM tasks WHERE lower(task_name) LIKE lower(:task_name) ORDER BY task_name")?;
     let task_iter = query.query_map(&[(":task_name", &name_param)], |row| {
         Ok(Task {
             id: row.get(0)?,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -218,7 +218,7 @@ impl FurtheranceWindow {
 
                 if task_input.text().len() >= FurtheranceWindow::MIN_PREFIX_LENGTH.try_into().unwrap() {
                     let task_autocomplete = task_input.completion().unwrap();
-                    let model = Self::update_list_model(task_name.to_string());
+                    let model = Self::update_list_model(task_name.to_string()).unwrap();
                     task_autocomplete.set_model(Some(&model));
                 }
             }));
@@ -544,16 +544,16 @@ impl FurtheranceWindow {
         imp.task_input.set_activates_default(true);
     }
 
-    fn update_list_model(task_name: String) -> gtk::ListStore {
+    fn update_list_model(task_name: String) -> Result<gtk::ListStore, anyhow::Error> {
         let col_types: [glib::Type; 1] = [glib::Type::STRING];
-        let mut task_list = database::get_list_by_name(task_name).unwrap();
+        let mut task_list = database::get_list_by_name(task_name)?;
         task_list.dedup_by(|a, b| a.task_name == b.task_name && a.tags == b.tags);
         let store = gtk::ListStore::new(&col_types);
 
         for task in task_list {
             store.set(&store.append(), &[(0, &task.to_string())]);
         }
-        store
+        Ok(store)
     }
 
     fn get_idle_time(&self) -> Result<u64, Box<dyn std::error::Error>> {


### PR DESCRIPTION
Hi, I wrote some changes to implement task autocompletion through a GTK input drop down. If accepted, this PR would close https://github.com/lakoliu/Furtherance/issues/103

There's a glitch in the drop down I don't know how to fix: when the query returns only one result, a empty whitespace is shown in the dropdown:

![imatge](https://github.com/lakoliu/Furtherance/assets/17052241/8828a12a-a535-49b0-b01d-fd4427033bc0)

I noticed some other strange behaviors, like:

- When the dropdown is open and I switch to another window, the dropdown keeps visible on top of other windows.
- Mouse selection inside the dropdown not always works.

I think these are probably bugs in GTK itself, as `gtk::EntryCompletion` is marked as deprecated. But I couldn't find any other component in GTK 4 which implements such functionality.

I took this task as an exercise to learn rust and GTK, so it could have made some beginner mistakes. Please review it with care, fortunately, it's not much code.