### PR TITLE
Port to libadwaita 1.4 widgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ version = "0.8.0"
 [dependencies.adw]
 package = "libadwaita"
 version = "0.6.0"
-features = ["v1_2"]
+features = ["v1_4"]

--- a/src/gtk/preferences_window.ui
+++ b/src/gtk/preferences_window.ui
@@ -10,15 +10,9 @@
             <property name="title" translatable="yes">Appearance</property>
             <property name="visible">True</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="dark_theme_switch">
                 <property name="title" translatable="yes">_Dark theme</property>
                 <property name="use_underline">True</property>
-                <property name="activatable_widget">dark_theme_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="dark_theme_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -34,24 +28,19 @@
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
-                  <object class="AdwActionRow">
+                  <object class="AdwSpinRow" id="notify_of_idle_spin">
                     <property name="title" translatable="yes">_Minutes to idle</property>
                     <property name="subtitle" translatable="yes">Number of minutes before the user is considered idle</property>
                     <property name="use_underline">True</property>
-                    <child>
-                      <object class="GtkSpinButton" id="notify_of_idle_spin">
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                          <object class="GtkAdjustment">
-                            <property name="upper">60</property>
-                            <property name="lower">1</property>
-                            <property name="step_increment">1</property>
-                            <property name="page_increment">10</property>
-                          </object>
-                        </property>
-                        <property name="numeric">True</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="upper">60</property>
+                        <property name="lower">1</property>
+                        <property name="step_increment">1</property>
+                        <property name="page_increment">10</property>
                       </object>
-                    </child>
+                    </property>
+                    <property name="numeric">True</property>
                   </object>
                 </child>
               </object>
@@ -69,24 +58,19 @@
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
-                  <object class="AdwActionRow">
+                  <object class="AdwSpinRow" id="pomodoro_spin">
                     <property name="title" translatable="yes">Interval</property>
                     <property name="subtitle" translatable="yes">Start time in minutes</property>
                     <property name="use_underline">True</property>
-                    <child>
-                      <object class="GtkSpinButton" id="pomodoro_spin">
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                          <object class="GtkAdjustment">
-                            <property name="upper">999</property>
-                            <property name="lower">1</property>
-                            <property name="step_increment">1</property>
-                            <property name="page_increment">15</property>
-                          </object>
-                        </property>
-                        <property name="numeric">True</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="upper">999</property>
+                        <property name="lower">1</property>
+                        <property name="step_increment">1</property>
+                        <property name="page_increment">15</property>
                       </object>
-                    </child>
+                    </property>
+                    <property name="numeric">True</property>
                   </object>
                 </child>
               </object>
@@ -98,38 +82,27 @@
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
-                  <object class="AdwActionRow">
+                  <object class="AdwSpinRow" id="autosave_spin">
                     <property name="title" translatable="yes">Autosave every X _minutes</property>
                     <property name="use_underline">True</property>
-                    <child>
-                      <object class="GtkSpinButton" id="autosave_spin">
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                          <object class="GtkAdjustment">
-                            <property name="upper">60</property>
-                            <property name="lower">1</property>
-                            <property name="step_increment">1</property>
-                            <property name="page_increment">10</property>
-                          </object>
-                        </property>
-                        <property name="numeric">True</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="upper">60</property>
+                        <property name="lower">1</property>
+                        <property name="step_increment">1</property>
+                        <property name="page_increment">10</property>
                       </object>
-                    </child>
+                    </property>
+                    <property name="numeric">True</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="inclusive_total_switch">
                 <property name="title" translatable="yes">Inclusive total time</property>
-                <property name="use_underline">True</property>
-                <property name="activatable_widget">inclusive_total_switch</property>
                 <property name="subtitle" translatable="yes">Today's total time includes the ongoing timer</property>
-                <child>
-                  <object class="GtkSwitch" id="inclusive_total_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="use_underline">True</property>
               </object>
             </child>
           </object>
@@ -145,15 +118,9 @@
             <property name="title" translatable="yes">Task List</property>
             <property name="visible">True</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="delete_confirmation_switch">
                 <property name="title" translatable="yes">_Delete confirmation</property>
                 <property name="use_underline">True</property>
-                <property name="activatable_widget">delete_confirmation_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="delete_confirmation_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
@@ -163,64 +130,41 @@
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
-                  <object class="AdwActionRow">
+                  <object class="AdwSpinRow" id="limit_days_spin">
                     <property name="title" translatable="yes">_Days ago</property>
                     <property name="subtitle" translatable="yes">Number of days to display in the list</property>
                     <property name="use_underline">True</property>
-                    <child>
-                      <object class="GtkSpinButton" id="limit_days_spin">
-                        <property name="valign">center</property>
-                        <property name="adjustment">
-                          <object class="GtkAdjustment">
-                            <property name="upper">365</property>
-                            <property name="lower">1</property>
-                            <property name="step_increment">1</property>
-                            <property name="page_increment">10</property>
-                          </object>
-                        </property>
-                        <property name="numeric">True</property>
+                    <property name="adjustment">
+                      <object class="GtkAdjustment">
+                        <property name="upper">365</property>
+                        <property name="lower">1</property>
+                        <property name="step_increment">1</property>
+                        <property name="page_increment">10</property>
                       </object>
-                    </child>
+                    </property>
+                    <property name="numeric">True</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="show_daily_sums_switch">
                 <property name="title" translatable="yes">Show daily sums</property>
                 <property name="use_underline">True</property>
-                <property name="activatable_widget">show_daily_sums_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="show_daily_sums_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="show_seconds_switch">
                 <property name="title" translatable="yes">_Show seconds</property>
-                <property name="use_underline">True</property>
-                <property name="activatable_widget">show_seconds_switch</property>
                 <property name="subtitle" translatable="yes">Tasks list only. Seconds always show on timer</property>
-                <child>
-                  <object class="GtkSwitch" id="show_seconds_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="use_underline">True</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="show_tags_switch">
                 <property name="title" translatable="yes">Show tags</property>
-                <property name="use_underline">True</property>
-                <property name="activatable_widget">show_tags_switch</property>
                 <property name="subtitle" translatable="yes">Tags are saved, just not shown</property>
-                <child>
-                  <object class="GtkSwitch" id="show_tags_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="use_underline">True</property>
               </object>
             </child>
           </object>
@@ -230,15 +174,9 @@
             <property name="title" translatable="yes">Task Input</property>
             <property name="visible">True</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwSwitchRow" id="autocomplete_switch">
                 <property name="title" translatable="yes">_Autocomplete</property>
                 <property name="use_underline">True</property>
-                <property name="activatable_widget">autocomplete_switch</property>
-                <child>
-                  <object class="GtkSwitch" id="autocomplete_switch">
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -282,7 +220,7 @@
                     <property name="valign">center</property>
                     <property name="label" translatable="yes">Browse</property>
                     <style>
-                      <class name="flat"/>
+                      <class name="flat" />
                     </style>
                   </object>
                 </child>
@@ -294,4 +232,3 @@
     </child>
   </template>
 </interface>
-

--- a/src/gtk/preferences_window.ui
+++ b/src/gtk/preferences_window.ui
@@ -4,32 +4,32 @@
     <child>
       <object class="AdwPreferencesPage">
         <property name="icon_name">emblem-system-symbolic</property>
-        <property name="title" translatable="yes">General</property>
+        <property name="title" translatable="yes" context="A page title of the preferences dialog">_General</property>
+        <property name="use_underline">True</property>
         <child>
           <object class="AdwPreferencesGroup" id="appearance_group">
             <property name="title" translatable="yes">Appearance</property>
             <property name="visible">True</property>
             <child>
               <object class="AdwSwitchRow" id="dark_theme_switch">
-                <property name="title" translatable="yes">_Dark theme</property>
-                <property name="use_underline">True</property>
+                <property name="title" translatable="yes">Dark Theme</property>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup" id="idle_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Idle</property>
             <property name="visible">True</property>
             <child>
               <object class="AdwExpanderRow" id="notify_of_idle_expander">
-                <property name="title" translatable="yes">Notify of idle</property>
-                <property name="subtitle" translatable="yes">(GNOME only)</property>
+                <property name="title" translatable="yes">_Notify of Idle</property>
+                <property name="subtitle" translatable="yes">(GNOME Only)</property>
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
                   <object class="AdwSpinRow" id="notify_of_idle_spin">
-                    <property name="title" translatable="yes">_Minutes to idle</property>
+                    <property name="title" translatable="yes">_Minutes to Idle</property>
                     <property name="subtitle" translatable="yes">Number of minutes before the user is considered idle</property>
                     <property name="use_underline">True</property>
                     <property name="adjustment">
@@ -48,7 +48,7 @@
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup" id="timer_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Timer</property>
             <property name="visible">True</property>
             <child>
@@ -59,8 +59,7 @@
                 <property name="use_underline">True</property>
                 <child>
                   <object class="AdwSpinRow" id="pomodoro_spin">
-                    <property name="title" translatable="yes">Interval</property>
-                    <property name="subtitle" translatable="yes">Start time in minutes</property>
+                    <property name="title" translatable="yes">_Start Time in Minutes</property>
                     <property name="use_underline">True</property>
                     <property name="adjustment">
                       <object class="GtkAdjustment">
@@ -83,7 +82,7 @@
                 <property name="use_underline">True</property>
                 <child>
                   <object class="AdwSpinRow" id="autosave_spin">
-                    <property name="title" translatable="yes">Autosave every X _minutes</property>
+                    <property name="title" translatable="yes">Autosave Every _X Minutes</property>
                     <property name="use_underline">True</property>
                     <property name="adjustment">
                       <object class="GtkAdjustment">
@@ -100,7 +99,7 @@
             </child>
             <child>
               <object class="AdwSwitchRow" id="inclusive_total_switch">
-                <property name="title" translatable="yes">Inclusive total time</property>
+                <property name="title" translatable="yes">In_clusive Total Time</property>
                 <property name="subtitle" translatable="yes">Today's total time includes the ongoing timer</property>
                 <property name="use_underline">True</property>
               </object>
@@ -112,27 +111,27 @@
     <child>
       <object class="AdwPreferencesPage" id="tasks_page">
         <property name="icon_name">view-list-symbolic</property>
-        <property name="title" translatable="yes" context="A page title of the preferences dialog">Tasks</property>
+        <property name="title" translatable="yes" context="A page title of the preferences dialog">_Tasks</property>
+        <property name="use_underline">True</property>
         <child>
-          <object class="AdwPreferencesGroup" id="task_list_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Task List</property>
             <property name="visible">True</property>
             <child>
               <object class="AdwSwitchRow" id="delete_confirmation_switch">
-                <property name="title" translatable="yes">_Delete confirmation</property>
+                <property name="title" translatable="yes">Delete _Confirmation</property>
                 <property name="use_underline">True</property>
               </object>
             </child>
             <child>
               <object class="AdwExpanderRow" id="limit_tasks_expander">
-                <property name="title" translatable="yes">Limit tasks shown</property>
-                <property name="subtitle" translatable="yes">Only show X number of days in the saved tasks list</property>
+                <property name="title" translatable="yes">_Limit History Shown</property>
+                <property name="subtitle" translatable="yes">Only show the specified number of days in the tasks list</property>
                 <property name="show_enable_switch">True</property>
                 <property name="use_underline">True</property>
                 <child>
                   <object class="AdwSpinRow" id="limit_days_spin">
-                    <property name="title" translatable="yes">_Days ago</property>
-                    <property name="subtitle" translatable="yes">Number of days to display in the list</property>
+                    <property name="title" translatable="yes">_Number of Days</property>
                     <property name="use_underline">True</property>
                     <property name="adjustment">
                       <object class="GtkAdjustment">
@@ -149,20 +148,20 @@
             </child>
             <child>
               <object class="AdwSwitchRow" id="show_daily_sums_switch">
-                <property name="title" translatable="yes">Show daily sums</property>
+                <property name="title" translatable="yes">Show Daily S_ums</property>
                 <property name="use_underline">True</property>
               </object>
             </child>
             <child>
               <object class="AdwSwitchRow" id="show_seconds_switch">
-                <property name="title" translatable="yes">_Show seconds</property>
+                <property name="title" translatable="yes">Show _Seconds</property>
                 <property name="subtitle" translatable="yes">Tasks list only. Seconds always show on timer</property>
                 <property name="use_underline">True</property>
               </object>
             </child>
             <child>
               <object class="AdwSwitchRow" id="show_tags_switch">
-                <property name="title" translatable="yes">Show tags</property>
+                <property name="title" translatable="yes">S_how Tags</property>
                 <property name="subtitle" translatable="yes">Tags are saved, just not shown</property>
                 <property name="use_underline">True</property>
               </object>
@@ -170,7 +169,7 @@
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup" id="task_input_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Task Input</property>
             <property name="visible">True</property>
             <child>
@@ -186,14 +185,15 @@
     <child>
       <object class="AdwPreferencesPage" id="data_page">
         <property name="icon_name">drive-harddisk-symbolic</property>
-        <property name="title" translatable="yes" context="A page title of the preferences dialog">Data</property>
+        <property name="title" translatable="yes" context="A page title of the preferences dialog">_Data</property>
+        <property name="use_underline">True</property>
         <child>
-          <object class="AdwPreferencesGroup" id="reports_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Reports</property>
             <property name="visible">True</property>
             <child>
               <object class="AdwComboRow" id="week_start_combo">
-                <property name="title" translatable="yes">Week starts on</property>
+                <property name="title" translatable="yes">_Week Starts On</property>
                 <property name="use_underline">True</property>
                 <property name="model">
                   <object class="GtkStringList">
@@ -208,13 +208,15 @@
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup" id="database_group">
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Database</property>
             <property name="visible">True</property>
             <child>
               <object class="AdwActionRow" id="database_loc_row">
-                <property name="title" translatable="yes">Database location</property>
+                <property name="title" translatable="yes">Database _Location</property>
                 <property name="subtitle" translatable="no">/location/</property>
+                <property name="use_underline">True</property>
+                <property name="activatable_widget">database_browse_btn</property>
                 <child>
                   <object class="GtkButton" id="database_browse_btn">
                     <property name="valign">center</property>

--- a/src/ui/preferences_window.rs
+++ b/src/ui/preferences_window.rs
@@ -33,20 +33,20 @@ mod imp {
     #[derive(Default, Debug, CompositeTemplate)]
     #[template(resource = "/com/lakoliu/Furtherance/gtk/preferences_window.ui")]
     pub struct FurPreferencesWindow {
+        // General Page
+        // Appearance Group
         #[template_child]
         pub appearance_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
         pub dark_theme_switch: TemplateChild<adw::SwitchRow>,
 
-        #[template_child]
-        pub idle_group: TemplateChild<adw::PreferencesGroup>,
+        // Idle Group
         #[template_child]
         pub notify_of_idle_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
         pub notify_of_idle_spin: TemplateChild<adw::SpinRow>,
 
-        #[template_child]
-        pub timer_group: TemplateChild<adw::PreferencesGroup>,
+        // Timer Group
         #[template_child]
         pub pomodoro_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
@@ -58,8 +58,8 @@ mod imp {
         #[template_child]
         pub inclusive_total_switch: TemplateChild<adw::SwitchRow>,
 
-        #[template_child]
-        pub task_list_group: TemplateChild<adw::PreferencesGroup>,
+        // Tasks Page
+        // Task List Group
         #[template_child]
         pub delete_confirmation_switch: TemplateChild<adw::SwitchRow>,
         #[template_child]
@@ -73,14 +73,16 @@ mod imp {
         #[template_child]
         pub show_tags_switch: TemplateChild<adw::SwitchRow>,
 
-        #[template_child]
-        pub task_input_group: TemplateChild<adw::PreferencesGroup>,
+        // Task Input Group
         #[template_child]
         pub autocomplete_switch: TemplateChild<adw::SwitchRow>,
 
+        // Data Page
+        // Reports Group
         #[template_child]
         pub week_start_combo: TemplateChild<adw::ComboRow>,
 
+        // Database Group
         #[template_child]
         pub database_loc_row: TemplateChild<adw::ActionRow>,
         #[template_child]

--- a/src/ui/preferences_window.rs
+++ b/src/ui/preferences_window.rs
@@ -36,49 +36,47 @@ mod imp {
         #[template_child]
         pub appearance_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
-        pub dark_theme_switch: TemplateChild<gtk::Switch>,
+        pub dark_theme_switch: TemplateChild<adw::SwitchRow>,
 
         #[template_child]
         pub idle_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
         pub notify_of_idle_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
-        pub notify_of_idle_spin: TemplateChild<gtk::SpinButton>,
-
-        #[template_child]
-        pub task_list_group: TemplateChild<adw::PreferencesGroup>,
-        #[template_child]
-        pub limit_tasks_expander: TemplateChild<adw::ExpanderRow>,
-        #[template_child]
-        pub limit_days_spin: TemplateChild<gtk::SpinButton>,
-        #[template_child]
-        pub delete_confirmation_switch: TemplateChild<gtk::Switch>,
-        #[template_child]
-        pub show_seconds_switch: TemplateChild<gtk::Switch>,
-        #[template_child]
-        pub show_daily_sums_switch: TemplateChild<gtk::Switch>,
-        #[template_child]
-        pub show_tags_switch: TemplateChild<gtk::Switch>,
-
-        #[template_child]
-        pub task_input_group: TemplateChild<adw::PreferencesGroup>,
-        #[template_child]
-        pub autocomplete_switch: TemplateChild<gtk::Switch>,
+        pub notify_of_idle_spin: TemplateChild<adw::SpinRow>,
 
         #[template_child]
         pub timer_group: TemplateChild<adw::PreferencesGroup>,
         #[template_child]
         pub pomodoro_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
-        pub pomodoro_spin: TemplateChild<gtk::SpinButton>,
-
+        pub pomodoro_spin: TemplateChild<adw::SpinRow>,
         #[template_child]
         pub autosave_expander: TemplateChild<adw::ExpanderRow>,
         #[template_child]
-        pub autosave_spin: TemplateChild<gtk::SpinButton>,
+        pub autosave_spin: TemplateChild<adw::SpinRow>,
+        #[template_child]
+        pub inclusive_total_switch: TemplateChild<adw::SwitchRow>,
 
         #[template_child]
-        pub inclusive_total_switch: TemplateChild<gtk::Switch>,
+        pub task_list_group: TemplateChild<adw::PreferencesGroup>,
+        #[template_child]
+        pub delete_confirmation_switch: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub limit_tasks_expander: TemplateChild<adw::ExpanderRow>,
+        #[template_child]
+        pub limit_days_spin: TemplateChild<adw::SpinRow>,
+        #[template_child]
+        pub show_daily_sums_switch: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub show_seconds_switch: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub show_tags_switch: TemplateChild<adw::SwitchRow>,
+
+        #[template_child]
+        pub task_input_group: TemplateChild<adw::PreferencesGroup>,
+        #[template_child]
+        pub autocomplete_switch: TemplateChild<adw::SwitchRow>,
 
         #[template_child]
         pub week_start_combo: TemplateChild<adw::ComboRow>,
@@ -209,7 +207,7 @@ impl FurPreferencesWindow {
                 window.reset_history_box();
             });
 
-        imp.limit_days_spin.connect_value_changed(move |_| {
+        imp.limit_days_spin.connect_value_notify(move |_| {
             let window = FurtheranceWindow::default();
             window.reset_history_box();
         });
@@ -240,7 +238,7 @@ impl FurPreferencesWindow {
                 window.refresh_timer();
         });
 
-        imp.pomodoro_spin.connect_value_changed(move |new_val| {
+        imp.pomodoro_spin.connect_value_notify(move |new_val| {
             settings_manager::set_int("pomodoro-time", new_val.value() as i32);
             let window = FurtheranceWindow::default();
             window.refresh_timer();
@@ -299,4 +297,3 @@ impl FurPreferencesWindow {
         }));
     }
 }
-


### PR DESCRIPTION
[SwitchRow](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SwitchRow.html) + [SpinRow](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.SpinRow.html)
Requires runtime-version 45 (and above) (See https://github.com/flathub/com.lakoliu.Furtherance/issues/9)

![image](https://github.com/lakoliu/Furtherance/assets/98428543/1a0f2162-d165-49cc-87c2-4b069c8b7e18)

TODO
- [x] Remove unused PreferencesGroup references/ids
- [x] Update [access keys](https://developer.gnome.org/hig/guidelines/keyboard.html)