### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.lakoliu.Furtherance.appdata.xml.in
+++ b/data/com.lakoliu.Furtherance.appdata.xml.in
@@ -2,11 +2,11 @@
 <component type="desktop-application">
   <id>com.lakoliu.Furtherance</id>
   <launchable type="desktop-id">com.lakoliu.Furtherance.desktop</launchable>
-  <name translatable="no">Furtherance</name>
+  <name translate="no">Furtherance</name>
   <summary>Track your time without being tracked</summary>
-  <developer_name translatable="no">Ricky Kresslein</developer_name>
+  <developer_name translate="no">Ricky Kresslein</developer_name>
   <developer id="in.kressle">
-    <name translatable="no">Ricky Kresslein</name>
+    <name translate="no">Ricky Kresslein</name>
   </developer>
   <update_contact>rk@lakoliu.com</update_contact>
   <translation type="gettext">furtherance</translation>
@@ -45,14 +45,14 @@
 
   <releases>
     <release version="1.8.3" date="2024-02-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed a bug causing crash when timer was restarted after a Pomodoro timer finished</li>
         </ul>
       </description>
     </release>
     <release version="1.8.2" date="2023-10-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Autocompletion</li>
           <li>Bug fixes</li>
@@ -60,12 +60,12 @@
       </description>
     </release>
     <release version="1.8.1" date="2023-06-16">
-      <description translatable="no">
+      <description translate="no">
         <p>Translation improvements</p>
       </description>
     </release>
     <release version="1.8.0" date="2023-06-05">
-      <description translatable="no">
+      <description translate="no">
         <p>1.8 is a big update for Furtherance!</p>
         <ul>
           <li>Add 'This week' and 'Last week' to Reports</li>
@@ -80,7 +80,7 @@
       </description>
     </release>
     <release version="1.7.0" date="2023-03-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Manually add new task to group</li>
           <li>Updated translations</li>
@@ -88,7 +88,7 @@
       </description>
     </release>
     <release version="1.6.0" date="2022-10-02">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>The location of the database is now changeable</li>
           <li>Backup database</li>
@@ -100,7 +100,7 @@
     <release version="1.5.4" date="2022-09-14" />
     <release version="1.5.3" date="2022-07-20" />
     <release version="1.5.2" date="2022-07-19">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>New icon!</li>
           <li>Dates are now ISO 8601 format</li>
@@ -109,7 +109,7 @@
     </release>
     <release version="1.5.1" date="2022-06-16" />
     <release version="1.5.0" date="2022-06-10">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added a button to restart tasks</li>
           <li>CSV Export</li>
@@ -119,7 +119,7 @@
       </description>
     </release>
     <release version="1.4.0" date="2022-06-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Generate reports of task history over a specified timeframe</li>
           <li>Bug fixes and improvements</li>
@@ -127,7 +127,7 @@
       </description>
     </release>
     <release version="1.3.0" date="2022-05-26">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Ability to add tasks manually</li>
           <li>Auto-save option</li>
@@ -136,7 +136,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2022-04-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Pomodoro-style countdown timer!</li>
           <li>Bug fixes</li>
@@ -144,7 +144,7 @@
       </description>
     </release>
     <release version="1.1.2" date="2022-04-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Ability to add tags!</li>
           <li>Fixed icon positioning</li>
@@ -156,7 +156,7 @@
     </release>
     <release version="1.1.1" date="2022-04-14" />
     <release version="1.1.0" date="2022-04-11">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Furtherance has a new icon! And lots of bug fixes and improvements.
         </p>
@@ -165,7 +165,7 @@
     <release version="1.0.9" date="2022-04-02" />
     <release version="1.0.8" date="2022-03-26" />
     <release version="1.0.7" date="2022-03-18">
-      <description translatable="no">
+      <description translate="no">
         <p>
           First stable release of Furtherance.
         </p>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html