### PR TITLE
Fixes wayland detection

### DIFF
--- a/src/tests/timer_tests.rs
+++ b/src/tests/timer_tests.rs
@@ -24,7 +24,7 @@ mod timer_tests {
         let expected = (
             "Check".to_string(),
             "Proj".to_string(),
-            "Bond james bond #007".to_string(),
+            "007 #bond james bond".to_string(),
             10.0,
         );
         assert_eq!(split_task_input(input), expected);

--- a/src/update/msg_helper_functions.rs
+++ b/src/update/msg_helper_functions.rs
@@ -584,8 +584,8 @@ pub fn detect_wayland() -> bool {
     #[cfg(target_os = "linux")]
     if let Ok(true) = env::var("XDG_SESSION_TYPE").map(|v| v == "wayland") {
         return true;
-    } else if let Ok(_) = env::var("WAYLAND_DISPLAY") {
-        return Path::new(&format!("/run/user/{}/wayland-0", get_current_uid())).exists();
+    } else if let Ok(wayland_display) = env::var("WAYLAND_DISPLAY") {
+        return Path::new(&format!("/run/user/{}/{}", get_current_uid(), wayland_display)).exists();
     }
 
     false


### PR DESCRIPTION
`WAYLAND_DISPLAY` can a value other than `wayland-0`.
If it does, wayland detection when `XDG_SESSION_TYPE` is not set wouldn’t work.

This PR fixes this.

---

**I also had to change a test output for it to work**: as the tags are set to lower case and sorted before joining on `#`, the first test couln’t pass.

was it an issue on my side ? Do the tests currently pass for you ?